### PR TITLE
Configure EAS Build

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,10 @@
 {
   "name": "GraduallyAdoptExpo2025",
-  "displayName": "GraduallyAdoptExpo2025"
+  "displayName": "GraduallyAdoptExpo2025",
+  "extra": {
+    "eas": {
+      "projectId": "a1717b27-eba4-46d1-ac64-5d41f2befb97"
+    }
+  },
+  "owner": "expo-production"
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,27 @@
+{
+  "cli": {
+    "version": ">= 16.17.3",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "development-simulator": {
+      "extends": "development",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}


### PR DESCRIPTION
## Why
- Repeatable builds for everyone, no configuration on your machine!
- Manages credentials for both ad hoc and store builds
- Auto-submits to the stores after a successful build
- Developers can run `eas build:dev` to automatically reuse or build a new development build based on a matching native fingerprint (once CNG is adopted)

## How
Followed directions at: https://docs.expo.dev/build/introduction/

1. Ran `eas init` to setup project on EAS
2. Ran `eas build:configure` to setup build profiles in eas.json
3. Added `development-simulator` profile for iOS simulators, extending from `development` profile

## Test Plan
- [x] Ran development builds for iOS simulator / Android