### PR TITLE
Add some EAS Workflows

### DIFF
--- a/.eas/workflows/preview-with-maestro.yaml
+++ b/.eas/workflows/preview-with-maestro.yaml
@@ -1,0 +1,69 @@
+name: preview-with-maestro
+
+jobs:
+  fingerprint:
+    environment: preview
+    type: fingerprint
+
+  android_get_build:
+    needs: [fingerprint]
+    type: get-build
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.android_fingerprint_hash }}
+      platform: android
+      profile: preview
+
+  android_repack:
+    needs: [android_get_build]
+    if: ${{ needs.android_get_build.outputs.build_id }}
+    type: repack
+    params:
+      build_id: ${{ needs.android_get_build.outputs.build_id }}
+
+  android_build:
+    needs: [android_get_build]
+    if: ${{ !needs.android_get_build.outputs.build_id }}
+    type: build
+    params:
+      platform: android
+      profile: preview
+
+  android_maestro:
+    after: [android_repack, android_build]
+    type: maestro
+    image: latest
+    params:
+      build_id: ${{ needs.android_repack.outputs.build_id || needs.android_build.outputs.build_id }}
+      flow_path: ['.maestro/preview-smoke.yaml']
+      record_screen: true
+  ios_get_build:
+    needs: [fingerprint]
+    type: get-build
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
+      platform: ios
+      profile: preview-simulator
+
+  ios_repack:
+    needs: [ios_get_build]
+    if: ${{ needs.ios_get_build.outputs.build_id }}
+    type: repack
+    params:
+      build_id: ${{ needs.ios_get_build.outputs.build_id }}
+
+  ios_build:
+    needs: [ios_get_build]
+    if: ${{ !needs.ios_get_build.outputs.build_id }}
+    type: build
+    params:
+      platform: ios
+      profile: preview-simulator
+
+  ios_maestro:
+    after: [ios_repack, ios_build]
+    type: maestro
+    image: latest
+    params:
+      build_id: ${{ needs.ios_repack.outputs.build_id || needs.ios_build.outputs.build_id }}
+      flow_path: ['.maestro/preview-smoke.yaml']
+      record_screen: true

--- a/.eas/workflows/update-on-pr.yaml
+++ b/.eas/workflows/update-on-pr.yaml
@@ -1,0 +1,12 @@
+name: Publish PR preview
+
+on:
+  pull_request:
+    branches: ['*']
+
+jobs:
+  publish_preview_update:
+    name: Publish preview update
+    type: update
+    params:
+      branch: ${{ github.ref_name || 'test' }}

--- a/.eas/workflows/update-preview-on-merge.yaml
+++ b/.eas/workflows/update-preview-on-merge.yaml
@@ -1,0 +1,22 @@
+name: Publish preview update
+
+on:
+  # Trigger on pushes to main branch
+  push:
+    branches: [main]
+
+jobs:
+  update_preview:
+    name: Update Preview Channel
+    type: update
+    params:
+      channel: preview
+  next_steps:
+    name: Next Steps
+    needs: [update_preview]
+    type: doc
+    params:
+      md: |
+        # To do next
+
+        Preview app has been updated. Open the app and go to Settings and apply the update.

--- a/.maestro/preview-smoke.yaml
+++ b/.maestro/preview-smoke.yaml
@@ -1,0 +1,4 @@
+appId: org.reactjs.native.example.GraduallyAdoptExpo2025
+---
+- launchApp
+- assertVisible: '.*Welcome to React Native.*'

--- a/README.md
+++ b/README.md
@@ -95,3 +95,5 @@ To learn more about React Native, take a look at the following resources:
 - [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
 - [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
 - [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
+
+small change to trigger PR preview

--- a/README.md
+++ b/README.md
@@ -95,5 +95,3 @@ To learn more about React Native, take a look at the following resources:
 - [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
 - [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
 - [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
-
-small change to trigger PR preview

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -38,7 +38,8 @@ target 'GraduallyAdoptExpo2025' do
   use_react_native!(
     :path => config[:reactNativePath],
     # An absolute path to your application root.
-    :app_path => "#{Pod::Config.instance.installation_root}/.."
+    :app_path => "#{Pod::Config.instance.installation_root}/..",
+    :hermes_enabled => true,
   )
 
   post_install do |installer|


### PR DESCRIPTION
## Why
I wanted to automate some tasks, such as publishing a PR preview update to run on a development build whenever a PR is updated, and update the Preview app when changes are pushed to main.

## How
- Followed directions at https://docs.expo.dev/eas/workflows/get-started/
- Connected my Github project to my Expo project at https://expo.dev
- Added a workflow for publishing an EAS Update when a PR is updated (for running on a development build)
- Added a workflow for publishing an EAS Update to the `preview` channel so our pre-production app gets updated whenever code is merged to main
- We need CNG to fully utilize this (since it uses Fingerprint), but also added a Maestro test workflow that either fully builds or repacks the app with updated JavaScript and then runs E2E tests (for future use).

## Test Plan
- [x] Update workflow ran automatically when I created this PR